### PR TITLE
Add Azure provider option

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -6,7 +6,7 @@ from typing import List
 
 logger = logging.getLogger(__name__)
 
-from api.openai_client import OpenAIClient
+from api.openai_client import OpenAIClient, AzureOpenAIClient
 from api.openrouter_client import OpenRouterClient
 from adalflow import GoogleGenAIClient, OllamaClient
 
@@ -30,6 +30,7 @@ CONFIG_DIR = os.environ.get('DEEPWIKI_CONFIG_DIR', None)
 CLIENT_CLASSES = {
     "GoogleGenAIClient": GoogleGenAIClient,
     "OpenAIClient": OpenAIClient,
+    "AzureOpenAIClient": AzureOpenAIClient,
     "OpenRouterClient": OpenRouterClient,
     "OllamaClient": OllamaClient
 }
@@ -67,10 +68,11 @@ def load_generator_config():
             if provider_config.get("client_class") in CLIENT_CLASSES:
                 provider_config["model_client"] = CLIENT_CLASSES[provider_config["client_class"]]
             # Fall back to default mapping based on provider_id
-            elif provider_id in ["google", "openai", "openrouter", "ollama"]:
+            elif provider_id in ["google", "openai", "openrouter", "ollama", "azure"]:
                 default_map = {
                     "google": GoogleGenAIClient,
                     "openai": OpenAIClient,
+                    "azure": AzureOpenAIClient,
                     "openrouter": OpenRouterClient,
                     "ollama": OllamaClient
                 }
@@ -168,7 +170,7 @@ def get_model_config(provider="google", model=None):
     Get configuration for the specified provider and model
 
     Parameters:
-        provider (str): Model provider ('google', 'openai', 'openrouter', 'ollama')
+        provider (str): Model provider ('google', 'openai', 'openrouter', 'ollama', 'azure')
         model (str): Model name, or None to use default model
 
     Returns:

--- a/api/config/generator.json
+++ b/api/config/generator.json
@@ -48,6 +48,17 @@
         }
       }
     },
+    "azure": {
+      "client_class": "AzureOpenAIClient",
+      "default_model": "gpt-4o",
+      "supportsCustomModel": true,
+      "models": {
+        "gpt-4o": {
+          "temperature": 0.7,
+          "top_p": 0.8
+        }
+      }
+    },
     "openrouter": {
       "default_model": "openai/gpt-4o",
       "supportsCustomModel": true,

--- a/api/openai_client.py
+++ b/api/openai_client.py
@@ -587,6 +587,15 @@ class OpenAIClient(ModelClient):
         return image_source
 
 
+class AzureOpenAIClient(OpenAIClient):
+    """OpenAI client defaults for Azure deployments."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        kwargs.setdefault("env_base_url_name", "AZURE_OPENAI_ENDPOINT")
+        kwargs.setdefault("env_api_key_name", "AZURE_OPENAI_KEY")
+        super().__init__(*args, **kwargs)
+
+
 # Example usage:
 if __name__ == "__main__":
     from adalflow.core import Generator


### PR DESCRIPTION
## Summary
- introduce `AzureOpenAIClient` for Azure defaults
- register the new client in the configuration loader
- add an `azure` provider entry in `generator.json`

## Testing
- `python -m compileall -q api`